### PR TITLE
WEB-61: Replace Redis with Dynamo for GraphQL cache

### DIFF
--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -32,7 +32,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server:${dependencyVersions.spring_boot}"
     implementation "org.springframework.boot:spring-boot-starter-validation:${dependencyVersions.spring_boot}"
     implementation "org.springframework.boot:spring-boot-starter-web:${dependencyVersions.spring_boot}"
-    implementation "org.springframework.boot:spring-boot-starter-data-redis:${dependencyVersions.spring_boot}"
     implementation "org.springframework.boot:spring-boot-starter-cache:${dependencyVersions.spring_boot}"
     implementation "org.springframework.boot:spring-boot-starter-jersey:${dependencyVersions.spring_boot}"
     implementation "org.modelmapper:modelmapper:${dependencyVersions.model_mapper}"
@@ -41,6 +40,10 @@ dependencies {
     implementation "commons-codec:commons-codec:1.15"
     implementation 'com.graphql-java:graphql-java-extended-scalars:19.1'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-62:3.5.0'
+    implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws}")
+    implementation "software.amazon.awssdk:dynamodb:${dependencyVersions.aws}"
+    implementation "software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws}"
+
     implementation project(":shared")
 
     runtimeOnly "io.micrometer:micrometer-registry-prometheus:${dependencyVersions.prometheus}"

--- a/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCache.java
+++ b/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCache.java
@@ -1,0 +1,177 @@
+package cricket.merstham.graphql.cache;
+
+import cricket.merstham.shared.utils.ObjectSerializer;
+import org.springframework.cache.Cache;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class DynamoCache implements Cache {
+
+    private final String name;
+    private final DynamoDbClient client;
+    private final DynamoCacheConfiguration configuration;
+    private final ObjectSerializer<Object> serializer = new ObjectSerializer<>();
+
+    public DynamoCache(String name, DynamoDbClient client, DynamoCacheConfiguration configuration) {
+        this.name = name;
+        this.client = client;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return client;
+    }
+
+    @Override
+    public ValueWrapper get(Object key) {
+        var item = getItem(key);
+        if (item.hasItem()) return () -> decodeItemData(item, Object.class);
+        return null;
+    }
+
+    @Override
+    public <T> T get(Object key, Class<T> type) {
+        var item = getItem(key);
+
+        return decodeItemData(item, type);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        ValueWrapper result = get(key);
+
+        return result != null ? (T) result.get() : putCacheValue(key, valueLoader);
+    }
+
+    private <T> T putCacheValue(Object key, Callable<T> valueLoader) {
+        try {
+            var value = valueLoader.call();
+
+            client.putItem(
+                    PutItemRequest.builder()
+                            .tableName(configuration.getTableName())
+                            .item(toItem(key, value))
+                            .build());
+
+            return value;
+
+        } catch (Exception e) {
+            throw new ValueRetrievalException(key, valueLoader, e);
+        }
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        putCacheValue(key, () -> value);
+    }
+
+    @Override
+    public void evict(Object key) {
+        client.deleteItem(
+                DeleteItemRequest.builder()
+                        .tableName(configuration.getTableName())
+                        .key(toKey(key))
+                        .build());
+    }
+
+    @Override
+    public void clear() {
+        Map<String, AttributeValue> startKey = Map.of();
+        QueryResponse result;
+        do {
+            result =
+                    client.query(
+                            QueryRequest.builder()
+                                    .keyConditions(
+                                            Map.of(
+                                                    configuration.getCacheNameAttributeName(),
+                                                    Condition.builder()
+                                                            .comparisonOperator(
+                                                                    ComparisonOperator.EQ)
+                                                            .attributeValueList(
+                                                                    AttributeValue.fromS(name))
+                                                            .build()))
+                                    .consistentRead(true)
+                                    .exclusiveStartKey(startKey)
+                                    .limit(300)
+                                    .attributesToGet(configuration.getKeyAttributeName())
+                                    .build());
+
+            if (result.hasItems()) {
+                for (Map<String, AttributeValue> item : result.items()) {
+                    evict(item.get(configuration.getKeyAttributeName()));
+                }
+            }
+            startKey = result.lastEvaluatedKey();
+        } while (result.hasLastEvaluatedKey() && !result.lastEvaluatedKey().isEmpty());
+    }
+
+    private <T> T decodeItemData(GetItemResponse item, Class<T> type) {
+        if (item.hasItem()) {
+            var data =
+                    serializer.deserialize(
+                            item.item()
+                                    .get(configuration.getDataAttributeName())
+                                    .b()
+                                    .asByteArray());
+            try {
+                return type.cast(data);
+            } catch (ClassCastException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private Map<String, AttributeValue> toKey(Object key) {
+        return Map.of(
+                configuration.getCacheNameAttributeName(), AttributeValue.fromS(name),
+                configuration.getKeyAttributeName(),
+                        AttributeValue.fromB(
+                                serializer.serializeAndWrap(key, SdkBytes::fromByteArray)));
+    }
+
+    private Map<String, AttributeValue> toItem(Object key, Object value) {
+        return Map.of(
+                configuration.getCacheNameAttributeName(), AttributeValue.fromS(name),
+                configuration.getKeyAttributeName(),
+                        AttributeValue.fromB(
+                                serializer.serializeAndWrap(key, SdkBytes::fromByteArray)),
+                configuration.getTimeToLiveAttributeName(), calculateTtl(),
+                configuration.getDataAttributeName(),
+                        AttributeValue.fromB(
+                                serializer.serializeAndWrap(value, SdkBytes::fromByteArray)));
+    }
+
+    private AttributeValue calculateTtl() {
+        var ttl = Instant.now().plusSeconds(configuration.getTimeToLive());
+        return AttributeValue.fromN(Long.toString(ttl.getEpochSecond()));
+    }
+
+    private GetItemResponse getItem(Object key) {
+        return client.getItem(
+                GetItemRequest.builder()
+                        .tableName(configuration.getTableName())
+                        .key(toKey(key))
+                        .build());
+    }
+}

--- a/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheConfiguration.java
+++ b/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheConfiguration.java
@@ -1,0 +1,22 @@
+package cricket.merstham.graphql.cache;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.URI;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "spring.cache.dynamodb")
+public class DynamoCacheConfiguration {
+    private String tableName;
+    private String cacheNameAttributeName = "cacheName";
+    private String keyAttributeName = "cacheKey";
+    private String dataAttributeName = "data";
+    private String timeToLiveAttributeName = "ttl";
+    private int timeToLive;
+    private String region;
+    private boolean createTable = true;
+    private URI endpoint = null;
+}

--- a/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheConfiguration.java
+++ b/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 import java.net.URI;
+import java.time.Duration;
 
 @Data
 @Configuration
@@ -15,7 +16,7 @@ public class DynamoCacheConfiguration {
     private String keyAttributeName = "cacheKey";
     private String dataAttributeName = "data";
     private String timeToLiveAttributeName = "ttl";
-    private int timeToLive;
+    private Duration timeToLive;
     private String region;
     private boolean createTable = true;
     private URI endpoint = null;

--- a/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheManager.java
+++ b/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheManager.java
@@ -1,5 +1,7 @@
 package cricket.merstham.graphql.cache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -9,6 +11,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class DynamoCacheManager implements CacheManager {
+
+    private static final Logger LOG = LogManager.getLogger(DynamoCacheManager.class);
 
     private final DynamoDbClient client;
     private final DynamoCacheConfiguration configuration;
@@ -22,9 +26,11 @@ public class DynamoCacheManager implements CacheManager {
     @Override
     public Cache getCache(String name) {
         if (caches.containsKey(name)) {
+            LOG.info("Reusing existing cache {}", name);
             return caches.get(name);
         }
 
+        LOG.info("Creating new cache {}", name);
         var cache = new DynamoCache(name, client, configuration);
         caches.put(name, cache);
         return cache;

--- a/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheManager.java
+++ b/graphql/src/main/java/cricket/merstham/graphql/cache/DynamoCacheManager.java
@@ -1,0 +1,37 @@
+package cricket.merstham.graphql.cache;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DynamoCacheManager implements CacheManager {
+
+    private final DynamoDbClient client;
+    private final DynamoCacheConfiguration configuration;
+    private final Map<String, DynamoCache> caches = new HashMap<>();
+
+    public DynamoCacheManager(DynamoDbClient client, DynamoCacheConfiguration configuration) {
+        this.client = client;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Cache getCache(String name) {
+        if (caches.containsKey(name)) {
+            return caches.get(name);
+        }
+
+        var cache = new DynamoCache(name, client, configuration);
+        caches.put(name, cache);
+        return cache;
+    }
+
+    @Override
+    public Collection<String> getCacheNames() {
+        return caches.keySet();
+    }
+}

--- a/graphql/src/main/java/cricket/merstham/graphql/configuration/CacheConfiguration.java
+++ b/graphql/src/main/java/cricket/merstham/graphql/configuration/CacheConfiguration.java
@@ -1,16 +1,28 @@
 package cricket.merstham.graphql.configuration;
 
-import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import cricket.merstham.graphql.cache.DynamoCacheConfiguration;
+import cricket.merstham.graphql.cache.DynamoCacheManager;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.TableClass;
+import software.amazon.awssdk.services.dynamodb.model.TimeToLiveSpecification;
+import software.amazon.awssdk.services.dynamodb.model.UpdateTimeToLiveRequest;
 
-import java.util.Set;
+import static java.util.Objects.nonNull;
 
-@Component
-@EnableRedisRepositories
+@Configuration
 @EnableCaching
 public class CacheConfiguration {
 
@@ -28,23 +40,71 @@ public class CacheConfiguration {
     public static final String FIXTURE_CACHE = "fixture";
 
     @Bean
-    public RedisCacheManagerBuilderCustomizer customizer() {
-        return builder ->
-                builder.initialCacheNames(
-                                Set.of(
-                                        MEMBER_SUMMARY_CACHE,
-                                        NEWS_SUMMARY_CACHE,
-                                        NEWS_SUMMARY_TOTAL_CACHE,
-                                        NEWS_ITEM_BY_ID_CACHE,
-                                        NEWS_ITEM_BY_PATH_CACHE,
-                                        EVENT_SUMMARY_CACHE,
-                                        EVENT_SUMMARY_TOTAL_CACHE,
-                                        EVENT_ITEM_BY_ID_CACHE,
-                                        EVENT_ITEM_BY_PATH_CACHE,
-                                        TEAM_CACHE,
-                                        ACTIVE_TEAM_CACHE,
-                                        FIXTURE_CACHE))
-                        .enableStatistics()
-                        .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig());
+    public CacheManager cacheManager(
+            DynamoDbClient client, DynamoCacheConfiguration configuration) {
+        if (configuration.isCreateTable() && !tableExists(client, configuration)) {
+            createTable(client, configuration);
+        }
+
+        return new DynamoCacheManager(client, configuration);
+    }
+
+    @Bean
+    public DynamoDbClient dynamoDbClient(DynamoCacheConfiguration configuration) {
+        var builder =
+                DynamoDbClient.builder()
+                        .credentialsProvider(DefaultCredentialsProvider.builder().build())
+                        .region(Region.of(configuration.getRegion()));
+        if (nonNull(configuration.getEndpoint())) {
+            builder.endpointOverride(configuration.getEndpoint());
+        }
+        return builder.build();
+    }
+
+    private static void createTable(DynamoDbClient client, DynamoCacheConfiguration configuration) {
+        client.createTable(
+                CreateTableRequest.builder()
+                        .tableName(configuration.getTableName())
+                        .billingMode("PAY_PER_REQUEST")
+                        .tableClass(TableClass.STANDARD)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(configuration.getCacheNameAttributeName())
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build(),
+                                AttributeDefinition.builder()
+                                        .attributeName(configuration.getKeyAttributeName())
+                                        .attributeType(ScalarAttributeType.B)
+                                        .build())
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .attributeName(configuration.getCacheNameAttributeName())
+                                        .keyType(KeyType.HASH)
+                                        .build(),
+                                KeySchemaElement.builder()
+                                        .attributeName(configuration.getKeyAttributeName())
+                                        .keyType(KeyType.RANGE)
+                                        .build())
+                        .build());
+        client.updateTimeToLive(
+                UpdateTimeToLiveRequest.builder()
+                        .tableName(configuration.getTableName())
+                        .timeToLiveSpecification(
+                                TimeToLiveSpecification.builder()
+                                        .attributeName(configuration.getTimeToLiveAttributeName())
+                                        .enabled(true)
+                                        .build())
+                        .build());
+    }
+
+    private static boolean tableExists(
+            DynamoDbClient client, DynamoCacheConfiguration configuration) {
+        try {
+            client.describeTable(
+                    DescribeTableRequest.builder().tableName(configuration.getTableName()).build());
+            return true;
+        } catch (ResourceNotFoundException ignored) {
+            return false;
+        }
     }
 }

--- a/graphql/src/main/resources/application.yml
+++ b/graphql/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
   cache:
     dynamodb:
       table-name: GraphQLCache
-      time-to-live: 300
+      time-to-live: 300s
       region: eu-west-2
       endpoint: ${DYNAMO_ENDPOINT:}
       create-table: true

--- a/graphql/src/main/resources/application.yml
+++ b/graphql/src/main/resources/application.yml
@@ -27,20 +27,17 @@ spring:
       printer:
         enabled: true
   cache:
-    redis:
-      time-to-live: 300s
-      key-prefix: "graph-cache:"
-      use-key-prefix: true
-      enable-statistics: false
+    dynamodb:
+      table-name: GraphQLCache
+      time-to-live: 300
+      region: eu-west-2
+      endpoint: ${DYNAMO_ENDPOINT:}
+      create-table: true
   security:
     oauth2:
       resourceserver:
         jwt:
           issuer-uri: ${COGNITO_ISSUER_URI:}
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
 
 management:
   server:

--- a/shared/src/main/java/cricket/merstham/shared/utils/ObjectSerializer.java
+++ b/shared/src/main/java/cricket/merstham/shared/utils/ObjectSerializer.java
@@ -1,0 +1,44 @@
+package cricket.merstham.shared.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.function.Function;
+
+public class ObjectSerializer<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectSerializer.class);
+
+    public byte[] serialize(T object) {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                ObjectOutputStream objectOutputStream =
+                        new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(object);
+
+            objectOutputStream.flush();
+            return byteArrayOutputStream.toByteArray();
+        } catch (IOException ex) {
+            LOG.error("Error serializing object", ex);
+            return null;
+        }
+    }
+
+    public <R> R serializeAndWrap(T object, Function<byte[], R> wrapper) {
+        return wrapper.apply(serialize(object));
+    }
+
+    public T deserialize(byte[] bytes) {
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+                ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
+            return (T) objectInputStream.readObject();
+        } catch (IOException | ClassNotFoundException ex) {
+            LOG.error("Error deserializing object", ex);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
- Add custom `CacheManager` and `Cache` class that use DynamoDB
- Remove Redis dependencies
- Amend Cache configuration class to return the new Dynamo cache manager