### PR TITLE
WEB-60: Updates to DynamoDB Session driver

### DIFF
--- a/frontend/src/main/java/cricket/merstham/website/frontend/session/DynamoSessionConfiguration.java
+++ b/frontend/src/main/java/cricket/merstham/website/frontend/session/DynamoSessionConfiguration.java
@@ -5,12 +5,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 import java.net.URI;
+import java.time.Duration;
 
 @Data
 @Configuration
 @ConfigurationProperties(prefix = "spring.session.dynamodb")
 public class DynamoSessionConfiguration {
-    private Integer maxInactiveIntervalInSeconds;
+    private Duration maxInactiveInterval;
     private String tableName;
     private String sessionIdAttributeName = "sessionId";
     private String ttlAttributeName = "ttl";

--- a/frontend/src/main/resources/application.yml
+++ b/frontend/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   session:
     dynamodb:
       table-name: ${DYNAMO_SESSION_TABLE:sessions}
-      max-inactive-interval-in-seconds: 3600
+      max-inactive-interval: 1h
       region: eu-west-2
       endpoint: ${DYNAMO_ENDPOINT:}
       create-table: ${DYNAMO_SESSION_CREATE_TABLE:true}

--- a/shared/src/main/java/cricket/merstham/shared/utils/ObjectSerializer.java
+++ b/shared/src/main/java/cricket/merstham/shared/utils/ObjectSerializer.java
@@ -24,7 +24,7 @@ public class ObjectSerializer<T> {
             return byteArrayOutputStream.toByteArray();
         } catch (IOException ex) {
             LOG.error("Error serializing object", ex);
-            return null;
+            return new byte[0];
         }
     }
 


### PR DESCRIPTION
- Use shared object serializer
- Change TTL config property to `Duration` rather than `int`